### PR TITLE
metadata passed through onSuccess callback

### DIFF
--- a/src/angular-plaid-link.js
+++ b/src/angular-plaid-link.js
@@ -20,8 +20,8 @@ angular.module('angular-plaid-link', [])
                                 loaded = true;
                                 _triggerCallback(onLoadCallback);
                             },
-                            onSuccess: function(token) {
-                                _triggerCallback(onSuccessCallback, token);
+                            onSuccess: function(token, metadata) {
+                                _triggerCallback(onSuccessCallback, token, metadata);
                             }
                         };
 


### PR DESCRIPTION
Fixes issue with metadata not being passed back through onSuccess callback (as compared to plaid's standard module)
